### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/Client/Assets/scrape_defaults.py
+++ b/Client/Assets/scrape_defaults.py
@@ -11,8 +11,8 @@ def main():
             saveDefault(locale, default)
 
 def getDefault(locale):
-    print("scraping: %s..." % locale)
-    url = "https://hg.mozilla.org/releases/l10n/mozilla-aurora/%s/raw-file/default/mobile/chrome/region.properties" % locale
+    print("scraping: {0!s}...".format(locale))
+    url = "https://hg.mozilla.org/releases/l10n/mozilla-aurora/{0!s}/raw-file/default/mobile/chrome/region.properties".format(locale)
     response = requests.get(url)
     if not response.ok:
         return
@@ -22,7 +22,7 @@ def getDefault(locale):
         values = line.strip().split("=")
         if len(values) == 2 and values[0].strip() == "browser.search.defaultenginename":
             default = values[1].strip()
-            print("  default:  %s" % default)
+            print("  default:  {0!s}".format(default))
             return default
 
 def saveDefault(locale, default):

--- a/Client/Assets/scrape_plugins.py
+++ b/Client/Assets/scrape_plugins.py
@@ -30,8 +30,8 @@ def getLocaleList():
     return response.text.strip().split("\n")
 
 def getFileList(locale):
-    print("scraping: %s..." % locale)
-    url = "https://hg.mozilla.org/releases/l10n/mozilla-aurora/%s/file/default/mobile/searchplugins" % locale
+    print("scraping: {0!s}...".format(locale))
+    url = "https://hg.mozilla.org/releases/l10n/mozilla-aurora/{0!s}/file/default/mobile/searchplugins".format(locale)
     response = requests.get(url)
     if not response.ok:
         return
@@ -40,8 +40,8 @@ def getFileList(locale):
     return tree.xpath('//a[@class="list"]/text()')
 
 def getFile(locale, file):
-    print("  downloading: %s..." % file)
-    url = "https://hg.mozilla.org/releases/l10n/mozilla-aurora/%s/raw-file/default/mobile/searchplugins/%s" % (locale, file)
+    print("  downloading: {0!s}...".format(file))
+    url = "https://hg.mozilla.org/releases/l10n/mozilla-aurora/{0!s}/raw-file/default/mobile/searchplugins/{1!s}".format(locale, file)
     result = urllib.urlretrieve(url)
     return result[0]
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:firefox-ios?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:firefox-ios?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
