### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/Client/Assets/scrape_defaults.py
+++ b/Client/Assets/scrape_defaults.py
@@ -7,7 +7,7 @@ def main():
     locales = os.listdir("SearchPlugins")
     for locale in locales:
         default = getDefault(locale)
-        if default != None:
+        if default is not None:
             saveDefault(locale, default)
 
 def getDefault(locale):

--- a/Client/Assets/scrape_plugins.py
+++ b/Client/Assets/scrape_plugins.py
@@ -13,7 +13,7 @@ def main():
     locales = getLocaleList()
     for locale in locales:
         files = getFileList(locale)
-        if files == None:
+        if files is None:
             continue
 
         print("found searchplugins")


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:firefox-ios?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:firefox-ios?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
